### PR TITLE
ci: add compose-buddy formula

### DIFF
--- a/.github/workflows/compose-buddy.yml
+++ b/.github/workflows/compose-buddy.yml
@@ -1,17 +1,17 @@
-name: Update adbfriend formula
+name: Update compose-buddy formula
 on:
   repository_dispatch:
-    types: [update-tap]
+    types: [update-compose-buddy]
   workflow_dispatch:
     inputs:
       version:
-        description: 'New version of adbfriend'
+        description: 'New version of compose-buddy'
         required: true
       sha:
         description: 'Expected sha of the zip release'
         required: true
 jobs:
-  adbfriend:
+  compose-buddy:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -38,12 +38,12 @@ jobs:
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Update Formula
-        run: bash .template/render.sh .template/adbfriend.rb Formula/adbfriend.rb "https://github.com/mikepenz/adbfriend/releases/download/${VERSION}/adbfriend-cli-shadow-${VERSION}.zip"
+        run: bash .template/render.sh .template/compose-buddy.rb Formula/compose-buddy.rb "https://github.com/mikepenz/compose-buddy/releases/download/${VERSION}/compose-buddy-cli-${VERSION}.zip"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-          commit-message: Update adbfriend to ${{ steps.combined.outputs.VERSION }}
-          title: Update adbfriend to ${{ steps.combined.outputs.VERSION }}
-          branch: update-adbfriend
+          commit-message: Update compose-buddy to ${{ steps.combined.outputs.VERSION }}
+          title: Update compose-buddy to ${{ steps.combined.outputs.VERSION }}
+          branch: update-compose-buddy
           base: main

--- a/.template/compose-buddy.rb
+++ b/.template/compose-buddy.rb
@@ -1,0 +1,15 @@
+class ComposeBuddy < Formula
+    desc "CLI for rendering and inspecting Jetpack Compose @Preview composables"
+    homepage "https://github.com/mikepenz/compose-buddy/"
+    url "https://github.com/mikepenz/compose-buddy/releases/download/${VERSION}/compose-buddy-cli-${VERSION}.zip"
+    sha256 "${SHA}"
+    version "${VERSION}"
+    license "Apache-2.0"
+    depends_on "openjdk"
+    def install
+        bin.install "compose-buddy"
+    end
+    test do
+        system "#{bin}/compose-buddy", "--help"
+    end
+end

--- a/.template/render.sh
+++ b/.template/render.sh
@@ -4,10 +4,11 @@ set -xe
 
 INPUT="$1"
 OUTPUT="$2"
+URL="$3"
 
 echo "Rendering for version $VERSION, expected sha is $SHA"
-URL="https://github.com/mikepenz/adbfriend/releases/download/${VERSION}/adbfriend-cli-shadow-${VERSION}.zip"
-SHA256="$(curl -L $URL | sha256sum | cut -d " " -f 1)"
+echo "URL: $URL"
+SHA256="$(curl -L "$URL" | sha256sum | cut -d " " -f 1)"
 echo "Calculated SHA256 $SHA256"
 
 if [ "$SHA" == "$SHA256" ]; then


### PR DESCRIPTION
## Summary
- Add `compose-buddy` formula template and update workflow (listens on `update-compose-buddy` dispatch)
- Generalize `.template/render.sh` to accept the release URL as a third argument instead of hardcoding adbfriend's URL
- Update `adbfriend.yml` to pass its URL explicitly (no behavior change)

## Test plan
- [ ] Trigger the new workflow manually via `workflow_dispatch` with a known version/sha once compose-buddy publishes its first tag
- [ ] Verify adbfriend workflow still renders correctly on the next adbfriend release
- [ ] Confirm generated `Formula/compose-buddy.rb` is installable via `brew install mikepenz/tap/compose-buddy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)